### PR TITLE
Label fill can now be a linear gradient

### DIFF
--- a/src/.internal/core/render/EditableLabel.ts
+++ b/src/.internal/core/render/EditableLabel.ts
@@ -2,7 +2,7 @@ import { Label, ILabelPrivate, ILabelSettings, ILabelEvents } from "./Label";
 import { Container } from "./Container";
 import { RoundedRectangle } from "./RoundedRectangle";
 import { Percent } from "../util/Percent"
-import { color } from "../util/Color";
+import { Color, color } from "../util/Color";
 
 
 import * as $utils from "../util/Utils"
@@ -231,7 +231,11 @@ export class EditableLabel extends Label {
 			});
 
 			// Remove textarea attributes
-			textarea.style.color = this.get("fill", color(0x000000)).toCSS(this.get("fillOpacity", 1));
+			const fill = this.get("fill", color(0x000000))
+			if (fill instanceof Color) {
+				textarea.style.color = fill.toCSS(this.get("fillOpacity", 1));
+			}
+
 			textarea.style.backgroundColor = "rgba(0, 0, 0, 0)";
 			textarea.style.border = "none";
 			textarea.style.outline = "none";

--- a/src/.internal/core/render/Label.ts
+++ b/src/.internal/core/render/Label.ts
@@ -1,4 +1,4 @@
-import type { Color } from "../util/Color";
+import { Color } from "../util/Color";
 import type { Percent } from "../util/Percent";
 import type { DataItem, IComponentDataItem } from "./Component";
 
@@ -8,7 +8,7 @@ import { Container, IContainerPrivate, IContainerSettings, IContainerEvents } fr
 
 import * as  $array from "../../core/util/Array";
 import * as  $type from "../../core/util/Type";
-import { LinearGradient } from "./gradients/LinearGradient";
+import type { LinearGradient } from "./gradients/LinearGradient";
 
 
 export interface ILabelSettings extends IContainerSettings {
@@ -386,7 +386,10 @@ export class Label extends Container {
 	protected _maybeUpdateHTMLColor() {
 		const htmlElement = this.getPrivate("htmlElement");
 		if (htmlElement && this.get("fill")) {
-			htmlElement.style.color = this.get("fill")!.toCSSHex();
+			const fill = this.get("fill")
+			if (fill instanceof Color) {
+				htmlElement.style.color = fill.toCSSHex();
+			}
 		}
 	}
 

--- a/src/.internal/core/render/Label.ts
+++ b/src/.internal/core/render/Label.ts
@@ -8,6 +8,7 @@ import { Container, IContainerPrivate, IContainerSettings, IContainerEvents } fr
 
 import * as  $array from "../../core/util/Array";
 import * as  $type from "../../core/util/Type";
+import { LinearGradient } from "./gradients/LinearGradient";
 
 
 export interface ILabelSettings extends IContainerSettings {
@@ -22,7 +23,7 @@ export interface ILabelSettings extends IContainerSettings {
 	/**
 	 * Text color.
 	 */
-	fill?: Color;
+	fill?: Color | LinearGradient;
 
 	/**
 	 * Text opacity.

--- a/src/.internal/core/render/backend/CanvasRenderer.ts
+++ b/src/.internal/core/render/backend/CanvasRenderer.ts
@@ -4,6 +4,7 @@ import {
 	IRenderer, IContainer, IDisplayObject, IGraphics, IRendererEvents, IMargin,
 	IText, ITextStyle, IRadialText, IPicture, IRendererEvent, ILayer, ICanvasOptions, BlendMode, IPointerEvent, Id
 } from "./Renderer";
+import { LinearGradient } from "../gradients/LinearGradient";
 import type { IBounds } from "../../util/IBounds";
 import type { IPoint } from "../../util/IPoint";
 import { Color } from "../../util/Color";
@@ -1758,6 +1759,11 @@ export class CanvasText extends CanvasDisplayObject implements IText {
 
 			context.save();
 			ghostContext.save();
+			const style = this.style
+			if (style.fill && this._localBounds && style.fill instanceof LinearGradient) {
+				this.style.fill = style.fill.getFillFromBounds(0, this._localBounds.right, 0, this._localBounds.bottom)
+			}
+
 			this._prerender(status);
 
 			// const lines = this.text.toString().replace(/\r/g, "").split(/\n/);

--- a/src/.internal/core/render/gradients/LinearGradient.ts
+++ b/src/.internal/core/render/gradients/LinearGradient.ts
@@ -40,13 +40,20 @@ export class LinearGradient extends Gradient {
 	 * @ignore
 	 */
 	public getFill(target: Sprite): IGradient {
-		const rotation = this.get("rotation", 0);
 		let bounds = this.getBounds(target);
 
 		let l = bounds.left || 0;
 		let r = bounds.right || 0;
 		let t = bounds.top || 0;
 		let b = bounds.bottom || 0;
+		return this.getFillFromBounds(l, r, t, b)
+	}
+
+	/**
+	 * @ignore
+	 */
+	public getFillFromBounds(l: number, r: number, t: number, b: number): IGradient {
+		const rotation = this.get("rotation", 0);
 
 		let cos = $math.cos(rotation);
 		let sin = $math.sin(rotation);


### PR DESCRIPTION
In amcharts 4 it was possible to use a linear gradient as the fill for a label. In amcharts 5 this is not possible (ref #1636). 

In amcharts 5 you can use the html property to set a linear gradient fill but then that label cannot be exported anymore (ref #1645)

This pull request adds the ability for the fill property of a label to be a linear gradient so that those labels can still be exported.  

If there are any changes that need to be made in order to merge this pull request please let me know and I'll make them as soon as possible.